### PR TITLE
Remove ToUniversal and just specify the DateTime Kind to UTC

### DIFF
--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Storage/InstantValueConverter.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Storage/InstantValueConverter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage
 
         private static Instant fromProvider(DateTime dateTime)
         {
-            return Instant.FromDateTimeUtc(dateTime.ToUniversalTime());
+            return Instant.FromDateTimeUtc(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc));
         }
     }
 }


### PR DESCRIPTION
EF Core gets a DateTime with a DateTime Kind of Unspecified. If you use the method `ToUniversal` it will also change the time according to the machines time zone. Since you make sure that the time is saved in UTC with `instant.ToDateTimeUtc` you only need to change the kind to UTC form Unspecified. I checked the implementation in my project and it works properly now.

This fixes #1 