### PR TITLE
Fixes #10 by updating EF Core to 5.0.0

### DIFF
--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NodaTime" Version="2.4.7" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Query/ExpressionTranslators/BaseNodaTimeMemberTranslator.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Query/ExpressionTranslators/BaseNodaTimeMemberTranslator.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using NodaTime;
@@ -23,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators
         }
 
 
-        public SqlExpression Translate(SqlExpression instance, MemberInfo member, Type returnType)
+        public SqlExpression Translate(SqlExpression instance, MemberInfo member, Type returnType, IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (member.DeclaringType == this._declaringType)
             {

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Query/ExpressionTranslators/BaseNodaTimeMethodCallTranslator.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Query/ExpressionTranslators/BaseNodaTimeMethodCallTranslator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Query;
+﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using System;
 using System.Collections.Generic;
@@ -33,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators
             _methodInfoDateDiffBigMapping = methodInfoDateDiffBigMapping;
         }
 
-        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments)
+        public SqlExpression Translate(SqlExpression instance, MethodInfo method, IReadOnlyList<SqlExpression> arguments, IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
             if (_methodInfoDateAddMapping != null && _methodInfoDateAddMapping.TryGetValue(method, out var dateAddPart))
             {

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.csproj
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
     <PackageReference Include="NodaTime" Version="2.4.7" />
   </ItemGroup>
 


### PR DESCRIPTION
A side effect is that we now need to target netstandard 2.1, or higher, meaning we can no longer support .NET Framework.