### PR TITLE
Fix/persist default values

### DIFF
--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/Models/RacingContext.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/Models/RacingContext.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.SqlServer.NodaTime.Extensions;
+
 using NodaTime;
+
 using SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.Logging;
-using System;
 
 namespace SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.Models
 {
@@ -13,8 +16,10 @@ namespace SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.Models
         {
         }
 
-        readonly TestLoggerFactory _loggerFactory
+        private readonly TestLoggerFactory _loggerFactory
             = new TestLoggerFactory();
+
+        public DbSet<SupportedNodaTypes> TypeResults { get; set; }
 
         public DbSet<LessPreciseRaceResult> LessPreciseRaceResults { get; set; }
 

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/Models/SupportedNodaTypes.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/Models/SupportedNodaTypes.cs
@@ -1,0 +1,23 @@
+﻿using NodaTime;
+
+namespace SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.Models
+{
+    public class SupportedNodaTypes
+    {
+        public int Id { get; set; }
+
+        public Duration DurationNonNull { get; set; }
+        public Duration? DurationNull { get; set; }
+        public Instant InstantNonNull { get; set; }
+        public Instant? InstantNull { get; set; }
+        public LocalDate LocalDateNonNull { get; set; } // SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM.
+        public LocalDate? LocalDateNull { get; set; }
+        public LocalDateTime LocalDateTimeNonNull { get; set; } // SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM.
+        public LocalDateTime? LocalDateTimeNull { get; set; }
+        public LocalTime LocalTimeNonNull { get; set; }
+        public LocalTime? LocalTimeNull { get; set; }
+        public OffsetDateTime OffsetDateTimeNonNull { get; set; }
+        public OffsetDateTime? OffsetDateTimeNull { get; set; }
+
+    }
+}

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/Models/SupportedNodaTypes.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/Models/SupportedNodaTypes.cs
@@ -10,9 +10,9 @@ namespace SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.Models
         public Duration? DurationNull { get; set; }
         public Instant InstantNonNull { get; set; }
         public Instant? InstantNull { get; set; }
-        public LocalDate LocalDateNonNull { get; set; } // SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM.
+        public LocalDate LocalDateNonNull { get; set; }
         public LocalDate? LocalDateNull { get; set; }
-        public LocalDateTime LocalDateTimeNonNull { get; set; } // SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM.
+        public LocalDateTime LocalDateTimeNonNull { get; set; }
         public LocalDateTime? LocalDateTimeNull { get; set; }
         public LocalTime LocalTimeNonNull { get; set; }
         public LocalTime? LocalTimeNull { get; set; }

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SupportedTypesTests.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SupportedTypesTests.cs
@@ -35,7 +35,7 @@ namespace SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests
 
             Assert.NotNull(raceResultFromDb);
 
-            await transaction.CommitAsync();
+            await transaction.RollbackAsync();
         }
     }
 }

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SupportedTypesTests.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SupportedTypesTests.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+using SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.Models;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests
+{
+    public class SupportedTypesTests : QueryTestBase
+    {
+        public SupportedTypesTests(DatabaseTestFixture databaseTestFixture, ITestOutputHelper output)
+            : base(databaseTestFixture)
+        {
+        }
+
+
+        [Fact]
+        public async Task AllSupported_NodatimeTypes_AreSavedCorrectly()
+        {
+            await using var transaction = await this.Db.Database.BeginTransactionAsync();
+
+            var sut = new SupportedNodaTypes();
+
+            await this.Db.AddAsync(sut);
+            await this.Db.SaveChangesAsync();
+
+            var newContext = new RacingContext(this.DbContextOptions);
+            await newContext.Database.UseTransactionAsync(transaction.GetDbTransaction());
+
+            var raceResultFromDb = await newContext.TypeResults.FirstOrDefaultAsync(x => x.Id == sut.Id);
+
+            Assert.NotNull(raceResultFromDb);
+
+            await transaction.CommitAsync();
+        }
+    }
+}

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.csproj
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/StevenRasmussen/EFCore.SqlServer.NodaTime</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Entity Framework Core;entity-framework-core;EF;Data;O/RM;EntityFrameworkCore;EFCore;Noda;NodaTime;Noda Time</PackageTags>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Storage/LocalDateTimeTypeMapping.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Storage/LocalDateTimeTypeMapping.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.Data.SqlClient;
-using Microsoft.EntityFrameworkCore.Storage;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Data;
 using System.Data.Common;
-using System.Text;
+
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage
 {
@@ -47,7 +46,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage
                     clrType,
                     new LocalDateTimeValueConverter()
                     ),
-                storeType);
+                storeType,
+                StoreTypePostfix.Precision,
+                storeType == "datetime2" ? System.Data.DbType.DateTime2 : System.Data.DbType.DateTime);
         }
 
         /// <summary>

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Storage/LocalDateTypeMapping.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Storage/LocalDateTypeMapping.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators;
+﻿using System;
+using System.Data;
+using System.Data.Common;
+
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Storage;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage
 {
@@ -43,7 +44,31 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage
                     clrType,
                     new LocalDateValueConverter()
                     ),
-                LocalDateTypeMappingSourcePlugin.SqlServerTypeName);
+                LocalDateTypeMappingSourcePlugin.SqlServerTypeName,
+                StoreTypePostfix.None,
+                System.Data.DbType.Date);
+        }
+        /// <summary>
+        ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+        ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+        ///     any release. You should only use it directly in your code with extreme caution and knowing that
+        ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+        /// </summary>
+        protected override void ConfigureParameter(DbParameter parameter)
+        {
+            base.ConfigureParameter(parameter);
+
+            // Workaround for a SQLClient bug
+            if (DbType == System.Data.DbType.Date)
+            {
+                ((SqlParameter)parameter).SqlDbType = SqlDbType.Date;
+            }
+
+            if (Size.HasValue
+                && Size.Value != -1)
+            {
+                parameter.Size = Size.Value;
+            }
         }
     }
 }


### PR DESCRIPTION
Fix SqlDateTime overflow. Must be between 1/1/1753 12:00:00 AM and 12/31/9999 11:59:59 PM. 
When default values are supplied on localdate and localdatetime types 

Fixes #13 