### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="NodaTime" Version="2.4.7" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="NodaTime" Version="2.4.8" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@StevenRasmussen, I found an issue in the SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj:

Packages Microsoft.EntityFrameworkCore.SqlServer v5.0.0, Microsoft.NET.Test.Sdk v16.2.0, NodaTime v2.4.7, xunit v2.4.0, xunit.runner.visualstudio v2.4.0 and coverlet.collector v1.0.1 transitively introduce 132 dependencies into EFCore.SqlServer.NodaTime’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/EFCore-SqlServer-NodaTime.html)), while Microsoft.EntityFrameworkCore.SqlServer v5.0.1, Microsoft.NET.Test.Sdk v16.3.0, NodaTime v2.4.8, xunit v2.4.1, xunit.runner.visualstudio v2.4.1 and coverlet.collector v1.2.0 can only introduce 103 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/EFCore-SqlServer-NodaTime_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose