### PR TITLE
Stop checking IMethodCallTranslatorPlugin in validation

### DIFF
--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/ServiceCollectionTests.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/ServiceCollectionTests.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.Models;
+using Xunit;
+
+namespace SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests;
+
+public class ServiceCollectionTests
+{
+    [Fact]
+    public void CustomServiceCollection_ShouldNotThrowError()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddEntityFrameworkSqlServer()
+            .AddNodaTime()
+            .BuildServiceProvider(true);
+
+        var builder = new DbContextOptionsBuilder<SimpleContext>()
+            .UseInternalServiceProvider(serviceProvider)
+            .UseSqlServer("Does not matter since we won't try to connect to the DB", opt => { opt.UseNodaTime(); });
+
+        using var dbContext = new SimpleContext(builder.Options);
+
+        dbContext.Add(new SupportedNodaTypes());
+        Assert.Equal(1, dbContext.ChangeTracker.Entries().Count());
+    }
+
+    private class SimpleContext : DbContext
+    {
+        public SimpleContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public DbSet<SupportedNodaTypes> TypeResults { get; set; }
+    }
+}

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Infrastructure/NodaTimeOptionsExtension.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/Infrastructure/NodaTimeOptionsExtension.cs
@@ -31,9 +31,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Infrastructure
                 using (var scope = internalServiceProvider.CreateScope())
                 {
                     // Instant
-                    if (scope.ServiceProvider.GetService<IEnumerable<IMethodCallTranslatorPlugin>>()
-                            ?.Any(s => s is InstantMethodCallTranslatorPlugin) != true ||
-                        scope.ServiceProvider.GetService<IEnumerable<IRelationalTypeMappingSourcePlugin>>()
+                    if (scope.ServiceProvider.GetService<IEnumerable<IRelationalTypeMappingSourcePlugin>>()
                            ?.Any(s => s is SqlServerNodaTimeTypeMappingSourcePlugin) != true)
                     {
                         throw new InvalidOperationException(Resources.ServicesMissing);


### PR DESCRIPTION
Fixes https://github.com/StevenRasmussen/EFCore.SqlServer.NodaTime/issues/27

The issue is that loading the type mapper in options validation causes a cycle in DbContext initialization.