### PR TITLE
Update to EF Core 7.0.0 release

### DIFF
--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.1.22426.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NodaTime" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.csproj
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.1.22426.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     <PackageReference Include="NodaTime" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Now EF 7 is a full release, updates the references from the pre-release version to the full release version 😄 

Ran the tests locally and all passed