### PR TITLE
Add repro tests for SqlServerStringTypeMapping collection type mapping

### DIFF
--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/LocalDateQueryTests.cs
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/LocalDateQueryTests.cs
@@ -193,5 +193,29 @@ namespace SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests
 
             Assert.Equal(6, raceResults.Count);
         }
+
+        [Fact]
+        public async Task LocalDate_ContainedByConstantDates()
+        {
+            var dates = new[]{ new LocalDate(2019, 1, 1), new LocalDate(2019, 2, 1) };
+            var raceResults = await this.Db.Race.Where(r => EF.Constant(dates).Contains(r.Date)).ToListAsync();
+            Assert.Equal(
+                condense($"{RaceSelectStatement} WHERE [r].[Date] IN ('2019-01-01', '2019-02-01')"),
+                condense(this.Db.Sql));
+
+            Assert.Equal(2, raceResults.Count);
+        }
+
+        [Fact]
+        public async Task LocalDate_ContainedByParameterDates()
+        {
+            var dates = new[]{ new LocalDate(2019, 1, 1), new LocalDate(2019, 2, 1) };
+            var raceResults = await this.Db.Race.Where(r => EF.Parameter(dates).Contains(r.Date)).ToListAsync();
+            Assert.Equal(
+                condense($"{RaceSelectStatement} WHERE -- TODO WRITE ME WHEN QUERY IS FIXED"),
+                condense(this.Db.Sql));
+
+            Assert.Equal(2, raceResults.Count);
+        }
     }
 }

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NodaTime" Version="3.2.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NodaTime" Version="3.2.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.csproj
+++ b/src/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime/SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="NodaTime" Version="3.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
+    <PackageReference Include="NodaTime" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As part of upgrading to .NET9 and EF Core 9, I stumbled on a breaking change in one of my queries. 

EF Core 9 fails on `SqlServerStringTypeMapping` when passing NodaTime `LocalDate` values as an SQL parameter to `.Contains()`, either implicitly or explicity with `EF.Parameter()`.

Error: **System.Diagnostics.UnreachableException: A SqlServerStringTypeMapping collection type mapping could not be found**

Test cases added to illustrate the problem:
- ✅ Constant dates: `Db.Race.Where(r => EF.Constant(dates).Contains(r.Date))`
- ❌ Parameter dates: `Db.Race.Where(r => EF.Parameter(dates).Contains(r.Date))`

Although there is a trivial workaround, do you know if it is possible for this library to handle this case without having to explicitly declare `Ef.Constant()`?



```
System.Diagnostics.UnreachableException
A SqlServerStringTypeMapping collection type mapping could not be found
   at Microsoft.EntityFrameworkCore.SqlServer.Query.Internal.SqlServerTypeMappingPostprocessor.ApplyTypeMappingsOnOpenJsonExpression(SqlServerOpenJsonExpression openJsonExpression, IReadOnlyList`1 typeMappings)
   at Microsoft.EntityFrameworkCore.SqlServer.Query.Internal.SqlServerTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.Query.SqlExpressions.SelectExpression.<VisitChildren>g__VisitList|117_0[T](List`1 list, Boolean inPlace, Boolean& changed, <>c__DisplayClass117_0&)
   at Microsoft.EntityFrameworkCore.Query.SqlExpressions.SelectExpression.VisitChildren(ExpressionVisitor visitor)
   at Microsoft.EntityFrameworkCore.Query.RelationalTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.SqlServer.Query.Internal.SqlServerTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.Query.SqlExpressions.InExpression.VisitChildren(ExpressionVisitor visitor)
   at Microsoft.EntityFrameworkCore.Query.RelationalTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.SqlServer.Query.Internal.SqlServerTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.Query.SqlExpressions.SelectExpression.VisitChildren(ExpressionVisitor visitor)
   at Microsoft.EntityFrameworkCore.Query.RelationalTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.SqlServer.Query.Internal.SqlServerTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.Query.RelationalTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.SqlServer.Query.Internal.SqlServerTypeMappingPostprocessor.VisitExtension(Expression expression)
   at Microsoft.EntityFrameworkCore.Query.RelationalTypeMappingPostprocessor.Process(Expression expression)
   at Microsoft.EntityFrameworkCore.SqlServer.Query.Internal.SqlServerQueryTranslationPostprocessor.ProcessTypeMappings(Expression expression)
   at Microsoft.EntityFrameworkCore.Query.RelationalQueryTranslationPostprocessor.Process(Expression query)
   at Microsoft.EntityFrameworkCore.SqlServer.Query.Internal.SqlServerQueryTranslationPostprocessor.Process(Expression query)
   at Microsoft.EntityFrameworkCore.Query.QueryCompilationContext.CreateQueryExecutorExpression[TResult](Expression query)
   at Microsoft.EntityFrameworkCore.Query.QueryCompilationContext.CreateQueryExecutor[TResult](Expression query)
   at Microsoft.EntityFrameworkCore.Storage.Database.CompileQuery[TResult](Expression query, Boolean async)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.CompileQueryCore[TResult](IDatabase database, Expression query, IModel model, Boolean async)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.<>c__DisplayClass11_0`1.<ExecuteCore>b__0()
   at Microsoft.EntityFrameworkCore.Query.Internal.CompiledQueryCache.GetOrAddQuery[TResult](Object cacheKey, Func`1 compiler)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.ExecuteCore[TResult](Expression query, Boolean async, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.ExecuteAsync[TResult](Expression query, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryProvider.ExecuteAsync[TResult](Expression expression, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.EntityQueryable`1.GetAsyncEnumerator(CancellationToken cancellationToken)
   at System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1.GetAsyncEnumerator()
   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync[TSource](IQueryable`1 source, CancellationToken cancellationToken)
```